### PR TITLE
[R+M] fix: equip ruby bolts at end of fight

### DIFF
--- a/autovorki/src/main/java/net.runelite.client.plugins.autovorki/AutoVorki.java
+++ b/autovorki/src/main/java/net.runelite.client.plugins.autovorki/AutoVorki.java
@@ -474,6 +474,10 @@ public class AutoVorki extends Plugin {
                     timeout = 3;
                     break;
                 case TELE_TO_POH:
+                    WidgetItem ruby = inv.getWidgetItem(rubyBolts);
+                    if (ruby != null) {
+                        actionItem(ruby.getId(), MenuAction.ITEM_SECOND_OPTION, 0);
+                    }
                     teleToPoH();
                     break;
                 case WITHDRAW_MAGIC_STAFF:


### PR DESCRIPTION
Equips ruby bolts if present at the end of the fight.  This makes banker smoother as currently if the the player has diamonds equipped the bank script searches for them when withdrawing items, causing the script to rebank.  This is creating a bad pattern I believe and I've tested this locally to work for me.