### PR TITLE
[R+M] fix: equip ruby bolts before banking

### DIFF
--- a/autovorki/src/main/java/net.runelite.client.plugins.autovorki/AutoVorki.java
+++ b/autovorki/src/main/java/net.runelite.client.plugins.autovorki/AutoVorki.java
@@ -469,6 +469,10 @@ public class AutoVorki extends Plugin {
                     deposited = false;
                     break;
                 case DEPOSIT_INVENTORY:
+                    WidgetItem ruby = inv.getWidgetItem(rubyBolts);
+                    if (ruby != null) {
+                        actionItem(ruby.getId(), MenuAction.ITEM_SECOND_OPTION, 0);
+                    }
                     bank.depositAll();
                     deposited = true;
                     timeout = 3;

--- a/autovorki/src/main/java/net.runelite.client.plugins.autovorki/AutoVorki.java
+++ b/autovorki/src/main/java/net.runelite.client.plugins.autovorki/AutoVorki.java
@@ -450,6 +450,10 @@ public class AutoVorki extends Plugin {
                     --timeout;
                     break;
                 case FIND_BANK:
+                    WidgetItem ruby = inv.getWidgetItem(rubyBolts);
+                    if (ruby != null) {
+                        actionItem(ruby.getId(), MenuAction.ITEM_SECOND_OPTION, 0);
+                    }
                     openBank();
                     timeout = 2;
                     break;
@@ -468,11 +472,7 @@ public class AutoVorki extends Plugin {
                     timeout = 2;
                     deposited = false;
                     break;
-                case DEPOSIT_INVENTORY:
-                    WidgetItem ruby = inv.getWidgetItem(rubyBolts);
-                    if (ruby != null) {
-                        actionItem(ruby.getId(), MenuAction.ITEM_SECOND_OPTION, 0);
-                    }
+                case DEPOSIT_INVENTORY:                    
                     bank.depositAll();
                     deposited = true;
                     timeout = 3;


### PR DESCRIPTION
Equips ruby bolts if present before banking. This makes banker smoother as currently if the the player has diamonds equipped the bank script searches for them when withdrawing items, causing the script to rebank. This is creating a bad pattern I believe and I've tested this locally to work for me.